### PR TITLE
Xmlm passes invalid characters into output

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -31,6 +31,16 @@ Executable xmltrip
  BuildDepends: xmlm
  CompiledObject: best
 
+Test charspace_1_0
+ Command: ../xmltrip.native charspace_1.0.xml
+ WorkingDirectory: test
+ TestTools: xmltrip
+
+Test charspace_1_1
+ Command: ../xmltrip.native charspace_1.1.xml
+ WorkingDirectory: test
+ TestTools: xmltrip
+
 Document api
  Title: Xmlm's documentation and API reference
  Type: ocamlbuild (0.3)

--- a/test/charspace_1.0.xml
+++ b/test/charspace_1.0.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<space>
+  <char></char>
+</space>

--- a/test/charspace_1.1.xml
+++ b/test/charspace_1.1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.1" encoding="UTF-8" ?>
+
+<space>
+  <char>&#27;</char>
+</space>


### PR DESCRIPTION
Character code 27 (ESC) passes unescaped into output XML. XML 1.0 requires absence of this and other control characters in its well-formedness criteria for documents. XML 1.1 allows this character with a numeric character reference.

Xmlm cannot consume ESC, emits ESC without escaping when found in `Data in XML 1.0 and XML 1.1 modes, and does not parse &#27; in XML 1.1 mode.
