### PR TITLE
Fix sequential processing example

### DIFF
--- a/test/examples.ml
+++ b/test/examples.ml
@@ -31,10 +31,10 @@ let prune_docs prune_list ic oc =
     let rec skip i d = match Xmlm.input i with
     | `El_start _ -> skip i (d + 1)
     | `El_end -> if d = 1 then () else skip i (d - 1)
-    | s -> skip i d
+    | _ -> skip i d
     in
     match Xmlm.peek i with
-    | `El_start tag when prune tag -> skip i 0; process i o d
+    | `El_start ((_, tag), attrs) when prune (tag, attrs) -> skip i 0; process i o d
     | `El_start _ -> copy i o; process i o (d + 1)
     | `El_end -> copy i o; if d = 0 then () else process i o (d - 1)
     | `Data _ -> copy i o; process i o d


### PR DESCRIPTION
This commit will fix the following error:
```
File "xmlm_demo.ml", line 36, characters 31-34:            
36 |     | `El_start tag when prune tag -> skip i 0; process i o d                                                     
                                    ^^^                    
Error: This expression has type Xmlm.tag = Xmlm.name * Xmlm.attribute list                                             
       but an expression was expected of type string * 'a  
       Type Xmlm.name = string * string is not compatible with type string
```

Here is a complete example that works as expected: https://gist.github.com/jubnzv/30d3c67604a260f358903192db10e55f#file-seq_demo-ml