### PR TITLE
Add support for ISO 8859-15 (Latin 9) encoding

### DIFF
--- a/src/xmlm.mli
+++ b/src/xmlm.mli
@@ -38,6 +38,7 @@ type encoding = [
   | `UTF_16BE
   | `UTF_16LE
   | `ISO_8859_1
+  | `ISO_8859_15
   | `US_ASCII ]
 
 type dtd = string option
@@ -352,7 +353,14 @@ module type S = sig
   type string
 
   type encoding = [
-    | `UTF_8 | `UTF_16 | `UTF_16BE | `UTF_16LE | `ISO_8859_1| `US_ASCII ]
+    | `UTF_8
+    | `UTF_16
+    | `UTF_16BE
+    | `UTF_16LE
+    | `ISO_8859_1
+    | `ISO_8859_15
+    | `US_ASCII ]
+
   type dtd = string option
   type name = string * string
   type attribute = name * string

--- a/test/test.ml
+++ b/test/test.ml
@@ -39,6 +39,22 @@ let decoder_strip_atts () =
     test_seq (str "<e a ='%s'></e>" v) (el "e" ~atts:[att "a" pv] [])
   in
   test_attv "  bla bli\n\n blo " "bla bli blo";
+  let test_iso_8859_15 v pv =
+    test_seq ~enc:(Some `ISO_8859_15) (str "<e>%s</e>" v) (el "e" [[`Data pv]])
+  in
+  List.iter
+    (fun (v,pv) -> test_iso_8859_15 v pv)
+    [
+      ("\065", "\u{0041}"); (* A -> A *)
+      ("\164", "\u{20AC}"); (* ¤ -> € *)
+      ("\166", "\u{0160}"); (* ¦ -> Š *)
+      ("\168", "\u{0161}"); (* ¨ -> š *)
+      ("\180", "\u{017D}"); (* ´ -> Ž *)
+      ("\184", "\u{017E}"); (* ¸ -> ž *)
+      ("\188", "\u{0152}"); (* ¼ -> Œ *)
+      ("\189", "\u{0153}"); (* ½ -> œ *)
+      ("\190", "\u{0178}"); (* ¾ -> Ÿ *)
+    ];
   ()
 
 let test () =


### PR DESCRIPTION
For ISO 8859-15 (Latin 9) encoded XML files, e.g.

```xml
<?xml version="1.0" encoding="ISO-8859-15"?>
<e/>
```

The library raises an `Unknown_encoding` exception during parsing:

```
Could not parse an XML document:
  (Failure "[line 1, col 43] unknown encoding (iso-8859-15)")
```

This PR adds support for the ISO 8859-15 encoding.

Specifically, it remaps six codes to the respective unicode code points of ISO 8859-15[^1] and leaves other codes to the mapping of ISO 8859-1 (Latin 1).

It also adds tests for remapped codes and one test case for `0x41` (`A`).

[^1]: https://www.iana.org/assignments/charset-reg/ISO-8859-15